### PR TITLE
Add bell driven state management

### DIFF
--- a/SB014.API/BAL/ITournamentLogic.cs
+++ b/SB014.API/BAL/ITournamentLogic.cs
@@ -1,4 +1,5 @@
 using SB014.API.Domain;
+using SB014.API.Models;
 
 namespace  SB014.API.BAL
 {
@@ -6,5 +7,7 @@ namespace  SB014.API.BAL
     {
         Tournament SetPreplay(Tournament tournament, out Game newPreplayGame);
         Tournament SetInplay(Tournament tournament, out Game newPreplayGame);
+        TournamentStateUpdateModel AddBell(Tournament tournament);
+        Tournament SetPostplay(Tournament tournament, out Game newPostplayGame);
     }
 }

--- a/SB014.API/BAL/TournamentLogic.cs
+++ b/SB014.API/BAL/TournamentLogic.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Linq;
 using SB014.API.DAL;
 using SB014.API.Domain;
+using SB014.API.Models;
+
 namespace SB014.API.BAL
 {
     public class TournamentLogic : ITournamentLogic
@@ -43,6 +47,10 @@ namespace SB014.API.BAL
                 case Domain.Enums.TournamentState.PrePlay:
                     
                 break;
+                case Domain.Enums.TournamentState.PostPlay:
+                    // Clear the post play game
+                    tournament.PostplayGameId = null;
+                break;
             }          
 
             return tournament;
@@ -54,8 +62,6 @@ namespace SB014.API.BAL
             switch (tournament.State)
             {
                 case Domain.Enums.TournamentState.NoPlay:
-                   
-                   
                     
                 break;
 
@@ -78,8 +84,64 @@ namespace SB014.API.BAL
                     
                     
                 break;
+                case Domain.Enums.TournamentState.PostPlay:
+                    break;
             }
             return tournament;
+        }    
+        public Tournament SetPostplay(Tournament tournament, out Game newPostplayGame)
+        {
+            newPostplayGame = null;
+            // Switch on the current state
+            switch (tournament.State)
+            {
+                case Domain.Enums.TournamentState.NoPlay:
+                    
+                break;
+
+                case Domain.Enums.TournamentState.InPlay:
+
+                    // Move inplay to Postplay
+                    tournament.PostplayGameId = tournament.InplayGameId;
+
+                    // Clear inplay game
+                    tournament.InplayGameId = null;
+                    
+                break;
+                case Domain.Enums.TournamentState.PrePlay:
+                    // Create a new postplay game
+                    newPostplayGame = this.GameLogic.BuildGame(tournament.Id, tournament.CluesPerGame);                      
+                    
+                    // New Postplay
+                    tournament.PostplayGameId = newPostplayGame.Id;
+                                        
+                break;
+                case Domain.Enums.TournamentState.PostPlay:
+                    break;
+            }
+            return tournament;
+        }      
+        public TournamentStateUpdateModel AddBell(Tournament tournament)
+        {
+            tournament.BellCounter ++;
+
+            // Get the state associated with the current bell counter from the Bell State Lookup Matrix
+            BellStateLookup bellStateLookup = (from m in tournament.BellStateLookupMatrix 
+                        where m.BellCounter == tournament.BellCounter
+                        select m).FirstOrDefault();
+            
+            // Reset bell counter to the initial  state bell counter if bell counter has no matching state
+            if(bellStateLookup == null){
+                int initialLookupBellCounter = tournament.BellStateLookupMatrix.Min(entry => entry.BellCounter);
+                bellStateLookup = tournament.BellStateLookupMatrix.Where(entry => entry.BellCounter == initialLookupBellCounter).FirstOrDefault();
+                if(bellStateLookup == null)
+                {
+                    throw new System.Exception("Cannot determine tournament initial state");
+                }
+                //Reset the bell counter
+                tournament.BellCounter = bellStateLookup.BellCounter;
+            }
+            return new TournamentStateUpdateModel{State = bellStateLookup.State};
         }
     }
 }

--- a/SB014.API/DAL/TournamentRepositoryFake.cs
+++ b/SB014.API/DAL/TournamentRepositoryFake.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using SB014.API.Domain;
+using SB014.API.Domain.Enums;
 
 namespace SB014.API.DAL
 {
@@ -19,7 +20,30 @@ namespace SB014.API.DAL
                     new Tournament 
                     {
                         Id = Guid.NewGuid(),
-                        CluesPerGame = 20
+                        CluesPerGame = 20,
+                        BellStateLookupMatrix = new List<BellStateLookup>
+                        {
+                            new BellStateLookup
+                            {
+                                BellCounter = 1,
+                                State = TournamentState.PrePlay
+                            },
+                            new BellStateLookup
+                            {
+                                BellCounter = 2,
+                                State = TournamentState.InPlay
+                            },
+                            new BellStateLookup
+                            {
+                                BellCounter = 3,
+                                State = TournamentState.InPlay
+                            }                            ,
+                            new BellStateLookup
+                            {
+                                BellCounter = 4,
+                                State = TournamentState.PostPlay
+                            }
+                        }
                     }
                 );               
             }

--- a/SB014.API/Domain/Enums/TournamentState.cs
+++ b/SB014.API/Domain/Enums/TournamentState.cs
@@ -4,6 +4,7 @@
     {
         NoPlay = 0,
         PrePlay = 1,
-        InPlay = 2
+        InPlay = 2,
+        PostPlay = 3
     } 
 }

--- a/SB014.API/Domain/Tournament.cs
+++ b/SB014.API/Domain/Tournament.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Collections.Generic;
 using SB014.API.Domain.Enums;
 
 namespace SB014.API.Domain
 {
+    public class BellStateLookup
+    {
+        public int BellCounter { get; set; }
+        public TournamentState State { get; set; }
+    }
     public class Tournament
     {
         public Guid Id { get; set; }
@@ -11,7 +17,7 @@ namespace SB014.API.Domain
         public Guid? PostplayGameId { get; set; }
 
         public int CluesPerGame { get; set; }
-
+        public List<BellStateLookup> BellStateLookupMatrix { get; set; }
         public TournamentState State {
             get{
                 if(this.PreplayGameId.HasValue == false
@@ -24,12 +30,18 @@ namespace SB014.API.Domain
                 {
                     return TournamentState.InPlay;
                 }
+                else if(this.PreplayGameId.HasValue && this.InplayGameId.HasValue == false && this.PostplayGameId.HasValue)
+                {
+                    return TournamentState.PostPlay;
+                }
                 else
                 {
                     return TournamentState.PrePlay;
                 }
             }
         }
+
+        public int BellCounter { get; set; }
     }
 
 

--- a/SB014.Tests/TournamentLogic_SetInplayShould.cs
+++ b/SB014.Tests/TournamentLogic_SetInplayShould.cs
@@ -11,8 +11,6 @@ namespace SB014.UnitTests.Api
 {
     public class TournamentLogic_SetInplayShould
     {
-
-
          [Fact]
          public void BuildNewPreplayGame_WhenInPrePlay()
          {
@@ -28,7 +26,7 @@ namespace SB014.UnitTests.Api
                 Id = new Guid(),
                 PreplayGameId = Guid.NewGuid(),
                 InplayGameId = null,
-                PostplayGameId = Guid.NewGuid(),
+                PostplayGameId = null,
                 CluesPerGame = 1
             },out Game newPreplayGame);
 
@@ -38,7 +36,7 @@ namespace SB014.UnitTests.Api
         [Fact]
         public void MoveExistingPreplayGameToInplay_WhenInPreplay()
         {
-         // Arrange
+            // Arrange
             var tournamentRepositoryMock = new Mock<ITournamentRepository>();
             var mapper = Helper.SetupMapper();
             var gameLogicFake = new Mock<IGameLogic>();
@@ -50,83 +48,78 @@ namespace SB014.UnitTests.Api
                 Id = new Guid(),
                 PreplayGameId = existingPreplayGameId,
                 InplayGameId = null,
-                PostplayGameId = Guid.NewGuid(),
+                PostplayGameId = null,
                 CluesPerGame = 1
             },out Game newPreplayGame);
 
             // Assert
             Assert.True(t.InplayGameId == existingPreplayGameId);
         }
+        [Fact]
+        public void LeaveTournamentUnchanged_WhenInPostPlay()
+        {
+            // Arrange
+            var tournamentRepositoryMock = new Mock<ITournamentRepository>();
+            var mapper = Helper.SetupMapper();
+            var gameLogicFake = new Mock<IGameLogic>();
+            gameLogicFake.Setup(m=>m.BuildGame(It.IsAny<Guid>(),It.IsAny<int>())).Returns(new Game());
+            ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryMock.Object, gameLogicFake.Object);            
+            
+            // Act
+            Tournament t = tournamentLogic.SetInplay(new Tournament{
+                Id = new Guid(),
+                PreplayGameId = Guid.NewGuid(),
+                InplayGameId = null,
+                PostplayGameId = Guid.NewGuid(),
+                CluesPerGame = 1
+            },out Game newPreplayGame);
 
+            // Act + Assert
+            Assert.True(t.State == TournamentState.PostPlay);
+        }
+        [Fact]
+        public void LeaveTournamentUnchanged_WhenInInPlay()
+        {
+            // Arrange
+            var tournamentRepositoryMock = new Mock<ITournamentRepository>();
+            var mapper = Helper.SetupMapper();
+            var gameLogicFake = new Mock<IGameLogic>();
+            gameLogicFake.Setup(m=>m.BuildGame(It.IsAny<Guid>(),It.IsAny<int>())).Returns(new Game());
+            ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryMock.Object, gameLogicFake.Object);            
+            
+            // Act
+            Tournament t = tournamentLogic.SetInplay(new Tournament{
+                Id = new Guid(),
+                PreplayGameId = Guid.NewGuid(),
+                InplayGameId = Guid.NewGuid(),
+                PostplayGameId = null,
+                CluesPerGame = 1
+            },out Game newPreplayGame);
 
-        // [Fact]
-        //  public void SetPreplayGame_WhenAllGamesAreUnSetAndNewPreplayGameCreated()
-        //  {
-        //     // Arrange
-        //     var tournamentRepositoryMock = new Mock<ITournamentRepository>();
-        //     var mapper = Helper.SetupMapper();
-        //     var gameLogicFake = new Mock<IGameLogic>();
-        //     Guid newPreplayGameId = new Guid();
-        //     gameLogicFake.Setup(m=>m.BuildGame(It.IsAny<Guid>(),It.IsAny<int>())).Returns(new Game{Id = newPreplayGameId});
-        //     ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryMock.Object, gameLogicFake.Object);
- 
-        //     // Act
-        //     Tournament t = tournamentLogic.SetPreplay(new Tournament{
-        //         Id = new Guid(),
-        //         PreplayGameId = null,
-        //         InplayGameId = null,
-        //         PostplayGameId = null,
-        //         CluesPerGame = 1
-        //     },out Game newPreplayGame);
+            // Act + Assert
+            Assert.True(t.State == TournamentState.InPlay);
+        }
+        [Fact]
+        public void LeaveTournamentUnchanged_WhenInNoPlay()
+        {
+            // Arrange
+            var tournamentRepositoryMock = new Mock<ITournamentRepository>();
+            var mapper = Helper.SetupMapper();
+            var gameLogicFake = new Mock<IGameLogic>();
+            gameLogicFake.Setup(m=>m.BuildGame(It.IsAny<Guid>(),It.IsAny<int>())).Returns(new Game());
+            ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryMock.Object, gameLogicFake.Object);            
+            
+            // Act
+            Tournament t = tournamentLogic.SetInplay(new Tournament{
+                Id = new Guid(),
+                PreplayGameId = null,
+                InplayGameId = null,
+                PostplayGameId = null,
+                CluesPerGame = 1
+            },out Game newPreplayGame);
 
-        //     // Assert
-        //     Assert.Equal(t.PreplayGameId, newPreplayGameId );
-        // }
-  
-        // [Fact]
-        // public void MoveExistingInplayGameToPostplay_WhenInplay()
-        // {
-        //  // Arrange
-        //     var tournamentRepositoryMock = new Mock<ITournamentRepository>();
-        //     var mapper = Helper.SetupMapper();
-        //     var gameLogicFake = new Mock<IGameLogic>();
-        //     gameLogicFake.Setup(m=>m.BuildGame(It.IsAny<Guid>(),It.IsAny<int>())).Returns(new Game());
-        //     ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryMock.Object, gameLogicFake.Object);
-        //     Guid existingInplayGameId = Guid.NewGuid();
-        //     // Act
-        //     Tournament t = tournamentLogic.SetPreplay(new Tournament{
-        //         Id = new Guid(),
-        //         PreplayGameId = Guid.NewGuid(),
-        //         InplayGameId = existingInplayGameId,
-        //         PostplayGameId = null,
-        //         CluesPerGame = 1
-        //     },out Game newPreplayGame);
-
-        //     // Assert
-        //     Assert.True(t.PostplayGameId == existingInplayGameId);
-        // }
-
-        // [Fact]
-        // public void ClearExistingInplayGame_WhenInplay()
-        // {
-        //  // Arrange
-        //     var tournamentRepositoryMock = new Mock<ITournamentRepository>();
-        //     var mapper = Helper.SetupMapper();
-        //     var gameLogicFake = new Mock<IGameLogic>();
-        //     gameLogicFake.Setup(m=>m.BuildGame(It.IsAny<Guid>(),It.IsAny<int>())).Returns(new Game());
-        //     ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryMock.Object, gameLogicFake.Object);
-        //     Guid existingInplayGameId = Guid.NewGuid();
-        //     // Act
-        //     Tournament t = tournamentLogic.SetPreplay(new Tournament{
-        //         Id = new Guid(),
-        //         PreplayGameId = Guid.NewGuid(),
-        //         InplayGameId = existingInplayGameId,
-        //         PostplayGameId = null,
-        //         CluesPerGame = 1
-        //     },out Game newPreplayGame);
-
-        //     // Assert
-        //     Assert.True(t.InplayGameId == null);
-        // }        
+            // Act + Assert
+            Assert.True(t.State == TournamentState.NoPlay);
+        }
     }
 }

--- a/SB014.Tests/TournamentLogic_SetPostPlayShould.cs
+++ b/SB014.Tests/TournamentLogic_SetPostPlayShould.cs
@@ -9,11 +9,10 @@ using SB014.API.Domain.Enums;
 
 namespace SB014.UnitTests.Api
 {
-    public class TournamentLogic_SetPreplayShould
-    {
-
-         [Fact]
-         public void BuildNewPreplayGame_WhenInNoPlay()
+    public class TournamentLogic_SetPostplayShould
+    { 
+        [Fact]
+         public void BuildNewPostplayGame_WhenInPrePlay()
          {
             // Arrange
             var tournamentRepositoryFake = new Mock<ITournamentRepository>();
@@ -23,89 +22,19 @@ namespace SB014.UnitTests.Api
             ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryFake.Object, gameLogicMock.Object);
 
             // Act
-            Tournament t = tournamentLogic.SetPreplay(new Tournament{
+            Tournament t = tournamentLogic.SetPostplay(new Tournament{
                 Id = new Guid(),
-                PreplayGameId = null,
+                PreplayGameId = Guid.NewGuid(),
                 InplayGameId = null,
                 PostplayGameId = null,
                 CluesPerGame = 1
-            },out Game newPreplayGame);
+            },out Game postPlayGame);
 
             // Assert
             gameLogicMock.Verify(mock => mock.BuildGame(It.IsAny<Guid>(), It.IsAny<int>()), Times.Once());         
-        }       
- 
-
-        [Fact]
-         public void SetPreplayGame_WhenInNoPlayAndNewPreplayGameCreated()
-         {
-            // Arrange
-            var tournamentRepositoryMock = new Mock<ITournamentRepository>();
-            var mapper = Helper.SetupMapper();
-            var gameLogicFake = new Mock<IGameLogic>();
-            Guid newPreplayGameId = new Guid();
-            gameLogicFake.Setup(m=>m.BuildGame(It.IsAny<Guid>(),It.IsAny<int>())).Returns(new Game{Id = newPreplayGameId});
-            ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryMock.Object, gameLogicFake.Object);
- 
-            // Act
-            Tournament t = tournamentLogic.SetPreplay(new Tournament{
-                Id = new Guid(),
-                PreplayGameId = null,
-                InplayGameId = null,
-                PostplayGameId = null,
-                CluesPerGame = 1
-            },out Game newPreplayGame);
-
-            // Assert
-            Assert.Equal(t.PreplayGameId, newPreplayGameId );
-        }
-        
-
-        [Fact]
-        public void ClearExistingInplayGame_WhenInplay()
-        {
-         // Arrange
-            var tournamentRepositoryMock = new Mock<ITournamentRepository>();
-            var mapper = Helper.SetupMapper();
-            var gameLogicFake = new Mock<IGameLogic>();
-            gameLogicFake.Setup(m=>m.BuildGame(It.IsAny<Guid>(),It.IsAny<int>())).Returns(new Game());
-            ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryMock.Object, gameLogicFake.Object);
-            Guid existingInplayGameId = Guid.NewGuid();
-            // Act
-            Tournament t = tournamentLogic.SetPreplay(new Tournament{
-                Id = new Guid(),
-                PreplayGameId = Guid.NewGuid(),
-                InplayGameId = existingInplayGameId,
-                PostplayGameId = null,
-                CluesPerGame = 1
-            },out Game newPreplayGame);
-
-            // Assert
-            Assert.True(t.InplayGameId == null);
-        }       
-        [Fact]
-        public void ClearExistingPostplayGame_WhenPostplay()
-        {
-         // Arrange
-            var tournamentRepositoryMock = new Mock<ITournamentRepository>();
-            var mapper = Helper.SetupMapper();
-            var gameLogicFake = new Mock<IGameLogic>();
-            gameLogicFake.Setup(m=>m.BuildGame(It.IsAny<Guid>(),It.IsAny<int>())).Returns(new Game());
-            ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryMock.Object, gameLogicFake.Object);
-            // Act
-            Tournament t = tournamentLogic.SetPreplay(new Tournament{
-                Id = new Guid(),
-                PreplayGameId = Guid.NewGuid(),
-                InplayGameId = null,
-                PostplayGameId = Guid.NewGuid(),
-                CluesPerGame = 1
-            },out Game newPreplayGame);
-
-            // Assert
-            Assert.True(t.PostplayGameId == null);
         }  
         [Fact]
-        public void LeaveTournamentUnchanged_WhenInPrePlay()
+        public void LeaveTournamentUnchanged_WhenInNoPlay()
         {
             // Arrange
             var tournamentRepositoryMock = new Mock<ITournamentRepository>();
@@ -115,16 +44,82 @@ namespace SB014.UnitTests.Api
             ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryMock.Object, gameLogicFake.Object);            
             
             // Act
-            Tournament t = tournamentLogic.SetPreplay(new Tournament{
+            Tournament t = tournamentLogic.SetPostplay(new Tournament{
                 Id = new Guid(),
-                PreplayGameId = Guid.NewGuid(),
+                PreplayGameId = null,
                 InplayGameId = null,
                 PostplayGameId = null,
                 CluesPerGame = 1
-            },out Game newPreplayGame);
+            },out Game postPlayGame);
 
             // Act + Assert
-            Assert.True(t.State == TournamentState.PrePlay);
-        }
+            Assert.True(t.State == TournamentState.NoPlay);
+        }  
+        [Fact]
+        public void LeaveTournamentUnchanged_WhenInPostPlay()
+        {
+            // Arrange
+            var tournamentRepositoryMock = new Mock<ITournamentRepository>();
+            var mapper = Helper.SetupMapper();
+            var gameLogicFake = new Mock<IGameLogic>();
+            gameLogicFake.Setup(m=>m.BuildGame(It.IsAny<Guid>(),It.IsAny<int>())).Returns(new Game());
+            ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryMock.Object, gameLogicFake.Object);            
+            
+            // Act
+            Tournament t = tournamentLogic.SetPostplay(new Tournament{
+                Id = new Guid(),
+                PreplayGameId = Guid.NewGuid(),
+                InplayGameId = null,
+                PostplayGameId = Guid.NewGuid(),
+                CluesPerGame = 1
+            },out Game postPlayGame);
+
+            // Act + Assert
+            Assert.True(t.State == TournamentState.PostPlay);
+        }  
+        [Fact]
+        public void MoveExistingInplayGameToPostplay_WhenInInplay()
+        {
+            // Arrange
+            var tournamentRepositoryMock = new Mock<ITournamentRepository>();
+            var mapper = Helper.SetupMapper();
+            var gameLogicFake = new Mock<IGameLogic>();
+            gameLogicFake.Setup(m=>m.BuildGame(It.IsAny<Guid>(),It.IsAny<int>())).Returns(new Game());
+            ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryMock.Object, gameLogicFake.Object);
+            Guid existingInplayGameId = Guid.NewGuid();
+            // Act
+            Tournament t = tournamentLogic.SetPostplay(new Tournament{
+                Id = new Guid(),
+                PreplayGameId = Guid.NewGuid(),
+                InplayGameId = existingInplayGameId,
+                PostplayGameId = null,
+                CluesPerGame = 1
+            },out Game postPlayGame);
+
+            // Assert
+            Assert.True(t.PostplayGameId == existingInplayGameId);
+        } 
+        [Fact]
+        public void ClearExistingInplayGame_WhenInInplay()
+        {
+         // Arrange
+            var tournamentRepositoryMock = new Mock<ITournamentRepository>();
+            var mapper = Helper.SetupMapper();
+            var gameLogicFake = new Mock<IGameLogic>();
+            gameLogicFake.Setup(m=>m.BuildGame(It.IsAny<Guid>(),It.IsAny<int>())).Returns(new Game());
+            ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryMock.Object, gameLogicFake.Object);
+
+            // Act
+            Tournament t = tournamentLogic.SetPostplay(new Tournament{
+                Id = new Guid(),
+                PreplayGameId = Guid.NewGuid(),
+                InplayGameId = Guid.NewGuid(),
+                PostplayGameId = null,
+                CluesPerGame = 1
+            },out Game postPlayGame);
+
+            // Assert
+            Assert.True(t.InplayGameId == null);
+        }  
     }
 }

--- a/SB014.Tests/Tournament_AddTournamentStateBellShould.cs
+++ b/SB014.Tests/Tournament_AddTournamentStateBellShould.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SB014.API.BAL;
+using SB014.API.Controllers;
+using SB014.API.DAL;
+using SB014.API.Domain;
+using SB014.API.Domain.Enums;
+using SB014.API.Models;
+using Xunit;
+
+namespace SB014.UnitTests.Api
+{
+    public class Tournament_AddTournamentStateBellShould
+    {
+        [Fact]
+        public void ReturnStatusNotFound_WhenTournamentDoesNotExist()
+        {
+            // Arrange
+            var tournamentRepositoryFake = new Mock<ITournamentRepository>();
+            var mapper = Helper.SetupMapper();
+            tournamentRepositoryFake.Setup(p=>p.Get(It.IsAny<Guid>())).Returns<Tournament>(null);
+            var gameLogicFake = new Mock<IGameLogic>();
+            var tournamnetLogicFake = new Mock<ITournamentLogic>();
+            var tournamentController = new TournamentController(tournamentRepositoryFake.Object, mapper, gameLogicFake.Object, tournamnetLogicFake.Object);
+
+            // Act 
+            var actionResult = tournamentController.AddTournamentStateBell(new Guid());
+
+            // Assert
+            Assert.IsType<NotFoundResult>(actionResult);
+        }
+        [Fact]
+         public void ApplyTournamentStateBellLogicRules()
+         {
+            // Arrange
+            var tournamentRepositoryFake = new Mock<ITournamentRepository>();
+            var mapper = Helper.SetupMapper();
+            tournamentRepositoryFake.Setup(p=>p.Get(It.IsAny<Guid>())).Returns(new Tournament{
+                                                                                            Id = new Guid(),
+                                                                                            PreplayGameId = Guid.NewGuid(),
+                                                                                            InplayGameId = null,
+                                                                                            PostplayGameId = Guid.NewGuid(),
+                                                                                            CluesPerGame = 1,
+                                                                                            BellCounter = 0});
+            var gameLogicFake = new Mock<IGameLogic>();
+            var tournamentLogicMock = new Mock<ITournamentLogic>();
+            tournamentLogicMock.Setup(t=>t.AddBell(It.IsAny<Tournament>())).Returns(new TournamentStateUpdateModel{State = TournamentState.NoPlay});
+            var tournamentController = new TournamentController(tournamentRepositoryFake.Object, mapper, gameLogicFake.Object, tournamentLogicMock.Object);
+            
+            // Act
+            var actionResult = tournamentController.AddTournamentStateBell(new Guid());
+            
+            // Assert
+            tournamentLogicMock.Verify(mocks=>mocks.AddBell(It.IsAny<Tournament>()), Times.Once);
+         }
+        
+        [Fact]
+        public void SaveTournament_WhenStateChangesDueToBellCounter()
+        {
+        // Arrange
+        var tournamentRepositoryMock = new Mock<ITournamentRepository>();
+        var mapper = Helper.SetupMapper();
+        var tournament = 
+            new Tournament{ 
+                Id = new Guid(),
+                PreplayGameId = null,
+                InplayGameId = null,
+                PostplayGameId = null,
+                CluesPerGame = 1,
+                BellCounter = 0,
+                BellStateLookupMatrix = new List<BellStateLookup>
+                {
+                    new BellStateLookup
+                    {
+                        BellCounter = 1,
+                        State = TournamentState.PrePlay
+                    },
+                    new BellStateLookup
+                    {
+                        BellCounter = 2,
+                        State = TournamentState.InPlay
+                    },
+                    new BellStateLookup
+                    {
+                        BellCounter = 3,
+                        State = TournamentState.InPlay
+                    }
+                }
+            };
+        tournamentRepositoryMock.Setup(p=>p.Get(It.IsAny<Guid>())).Returns(tournament);
+        var gameLogicFake = new Mock<IGameLogic>();        
+        var tournamentLogicFake = new Mock<ITournamentLogic>();
+        tournamentLogicFake.Setup(t=>t.AddBell(It.IsAny<Tournament>())).Returns(new TournamentStateUpdateModel{State = TournamentState.NoPlay});
+        var tournamentController = new TournamentController(tournamentRepositoryMock.Object, mapper, gameLogicFake.Object, tournamentLogicFake.Object);
+
+        // Act
+        var actionResult = tournamentController.AddTournamentStateBell(new Guid());
+
+        // Assert
+        tournamentRepositoryMock.Verify(mocks=>mocks.Update(It.IsAny<Tournament>()), Times.Once);
+        }
+    }
+}

--- a/SB014.Tests/TournamnetLogic_AddBellShould.cs
+++ b/SB014.Tests/TournamnetLogic_AddBellShould.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using Moq;
+using SB014.API.BAL;
+using SB014.API.DAL;
+using SB014.API.Domain;
+using SB014.API.Domain.Enums;
+using Xunit;
+
+namespace SB014.UnitTests.Api
+{
+    public class TournamentLogic_AddBellShould
+    {
+        [Fact]
+        public void SetTournamentBellCounter()
+        {
+            // Arrange
+            var tournamentRepositoryFake = new Mock<ITournamentRepository>();
+            var mapper = Helper.SetupMapper();
+            var gameLogicFake = new Mock<IGameLogic>();
+            ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryFake.Object, gameLogicFake.Object);
+            Tournament tournament = new Tournament{
+                BellCounter = 0,
+                BellStateLookupMatrix = new List<BellStateLookup>
+                {
+                    new BellStateLookup
+                    {
+                        BellCounter = 1,
+                        State = TournamentState.PrePlay
+                    },
+                    new BellStateLookup
+                    {
+                        BellCounter = 2,
+                        State = TournamentState.PrePlay
+                    },
+                    new BellStateLookup
+                    {
+                        BellCounter = 3,
+                        State = TournamentState.InPlay
+                    }
+                }};
+            
+            // Act
+            tournamentLogic.AddBell(tournament);
+
+            // Assert
+            Assert.NotEqual(0,tournament.BellCounter);
+        }
+        [Fact]
+        public void SaveTournament_WhenStateChangesDueToBellCounter()
+        {
+            // Arrange
+            var tournamentRepositoryFake = new Mock<ITournamentRepository>();
+            var mapper = Helper.SetupMapper();
+            var gameLogicFake = new Mock<IGameLogic>();
+            ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryFake.Object, gameLogicFake.Object);
+            Tournament tournament = new Tournament{
+                BellCounter = 0,
+                BellStateLookupMatrix = new List<BellStateLookup>
+                {
+                    new BellStateLookup
+                    {
+                        BellCounter = 1,
+                        State = TournamentState.PrePlay
+                    },
+                    new BellStateLookup
+                    {
+                        BellCounter = 2,
+                        State = TournamentState.PrePlay
+                    },
+                    new BellStateLookup
+                    {
+                        BellCounter = 3,
+                        State = TournamentState.InPlay
+                    }
+                }};
+            
+            // Act
+            tournamentLogic.AddBell(tournament);
+
+            // Assert
+            Assert.NotEqual(0,tournament.BellCounter);
+        }        
+        [Fact]
+        public void DetermineNewTournamentState_WhenBellStateMatrixAvailable()
+        {
+            // Arrange
+            var tournamentRepositoryFake = new Mock<ITournamentRepository>();
+            var mapper = Helper.SetupMapper();
+            var gameLogicFake = new Mock<IGameLogic>();
+            ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryFake.Object, gameLogicFake.Object);
+            Tournament tournament = new Tournament{
+                BellCounter = 0,
+                BellStateLookupMatrix = new List<BellStateLookup>
+                {
+                    new BellStateLookup
+                    {
+                        BellCounter = 1,
+                        State = TournamentState.PrePlay
+                    },
+                    new BellStateLookup
+                    {
+                        BellCounter = 2,
+                        State = TournamentState.PrePlay
+                    },
+                    new BellStateLookup
+                    {
+                        BellCounter = 3,
+                        State = TournamentState.InPlay
+                    }
+                }
+            };
+            // Act
+            var newState = tournamentLogic.AddBell(tournament);
+
+            // Assert
+            Assert.Equal( TournamentState.PrePlay, newState.State);
+
+        }
+        [Fact]
+        public void ResetBellCounterToInitialState_WhenNoBellStateDefinedForBellCounter()
+        {
+            // Arrange
+            var tournamentRepositoryFake = new Mock<ITournamentRepository>();
+            var mapper = Helper.SetupMapper();
+            var gameLogicFake = new Mock<IGameLogic>();
+            ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryFake.Object, gameLogicFake.Object);
+            Tournament tournament = new Tournament{
+                BellCounter = 100,
+                BellStateLookupMatrix = new List<BellStateLookup>
+                {
+                    new BellStateLookup
+                    {
+                        BellCounter = 1,
+                        State = TournamentState.PrePlay
+                    },
+                    new BellStateLookup
+                    {
+                        BellCounter = 2,
+                        State = TournamentState.PrePlay
+                    },
+                    new BellStateLookup
+                    {
+                        BellCounter = 3,
+                        State = TournamentState.InPlay
+                    }
+                }
+            };
+        
+            // Act
+            var newState = tournamentLogic.AddBell(tournament);
+        
+            // Assert
+            //Assert.Equal( TournamentState.PrePlay, newState.State);
+            Assert.Equal( 1, tournament.BellCounter);
+        }
+        [Fact]
+        public void ReturnInitialState_WhenNoBellStateDefinedForBellCounter()
+        {
+            // Arrange
+            var tournamentRepositoryFake = new Mock<ITournamentRepository>();
+            var mapper = Helper.SetupMapper();
+            var gameLogicFake = new Mock<IGameLogic>();
+            ITournamentLogic tournamentLogic = new TournamentLogic(tournamentRepositoryFake.Object, gameLogicFake.Object);
+            Tournament tournament = new Tournament{
+                BellCounter = 100,
+                BellStateLookupMatrix = new List<BellStateLookup>
+                {
+                    new BellStateLookup
+                    {
+                        BellCounter = 1,
+                        State = TournamentState.PrePlay
+                    },
+                    new BellStateLookup
+                    {
+                        BellCounter = 2,
+                        State = TournamentState.InPlay
+                    },
+                    new BellStateLookup
+                    {
+                        BellCounter = 3,
+                        State = TournamentState.InPlay
+                    }
+                }
+            };
+        
+            // Act
+            var newState = tournamentLogic.AddBell(tournament);
+        
+            // Assert
+            Assert.Equal( TournamentState.PrePlay, newState.State);
+        }    
+    }
+}


### PR DESCRIPTION
Allows tournament state to be progressed using an external timing mechanism that adds a "bell" to the tournament periodically that increments a bell count. The tournaments defines it's own life cycle in a table that maps a bell count to a state (resetting to initial state when counter reaches unmapped count).
